### PR TITLE
patch get_active_jobs handler

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,7 @@ pipeline {
                             curl -LOs "${SOURCE_TARBALL_URL}"
                             cp ../packaging/fedora/libds3v5.spec .
                             cp -R ../packaging/debian/libds3v5/debian debian
+                            cp debian/patches/*.patch .
                         """
                     }
                     stash(name: env.SOURCE_STASH, includes: "${env.SOURCE_STASH}/**/*")

--- a/packaging/debian/libds3v5/debian/changelog.in
+++ b/packaging/debian/libds3v5/debian/changelog.in
@@ -1,3 +1,9 @@
+libds3v5 (5.0.0-8~a1.@distro@) @distro@; urgency=low
+
+  * Patch get_active_jobs request
+
+ -- Globus Toolkit <support@globus.org>  Thu, 6 Mar 2025 16:42:22 -0600
+
 libds3v5 (5.0.0-7.@distro@) @distro@; urgency=low
 
   * Rebuild for new OS releases

--- a/packaging/debian/libds3v5/debian/patches/active_jobs.patch
+++ b/packaging/debian/libds3v5/debian/patches/active_jobs.patch
@@ -1,0 +1,23 @@
+diff --git a/src/ds3_requests.c b/src/ds3_requests.c
+index 310fdae6..b3edebc2 100644
+--- a/src/ds3_requests.c
++++ b/src/ds3_requests.c
+@@ -10544,7 +10544,7 @@ static ds3_error* _parse_top_level_ds3_active_job_list_response(const ds3_client
+     ds3_error* error = NULL;
+     GPtrArray* active_jobs_array = g_ptr_array_new();
+ 
+-    error = _get_request_xml_nodes(xml_blob, &doc, &root, "Jobs");
++    error = _get_request_xml_nodes(xml_blob, &doc, &root, "Data");
+     if (error != NULL) {
+         return error;
+     }
+@@ -15556,7 +15556,8 @@ ds3_error* ds3_get_active_jobs_spectra_s3_request(const ds3_client* client, cons
+ 
+     error = _parse_top_level_ds3_active_job_list_response(client, request, response, xml_blob);
+ 
+-    (*response)->paging = _parse_paging_headers(return_headers);
++    if (error == NULL)
++        (*response)->paging = _parse_paging_headers(return_headers);
+     ds3_string_multimap_free(return_headers);
+ 
+     return error;

--- a/packaging/debian/libds3v5/debian/patches/series
+++ b/packaging/debian/libds3v5/debian/patches/series
@@ -1,0 +1,1 @@
+active_jobs.patch

--- a/packaging/fedora/libds3v5.spec
+++ b/packaging/fedora/libds3v5.spec
@@ -5,7 +5,7 @@ Name:		libds3v5
 %global         debug_package %{nil}
 
 Version:	5.0.0
-Release:	7%{?dist}
+Release:	8~a1%{?dist}
 Vendor:		Globus Support
 Summary:	Spectra S3 C SDK
 
@@ -91,6 +91,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/pkgconfig/%{name}.pc
 
 %changelog
+* Thu Mar 6 2025 Globus Toolkit <support@globus.org> - 5.0.0-8~a1
+- Patch get_active_jobs request
+
 * Fri Nov 12 2021 Globus Toolkit <support@globus.org> - 5.0.0-7
 - Rebuild for new OS releases
 

--- a/packaging/fedora/libds3v5.spec
+++ b/packaging/fedora/libds3v5.spec
@@ -13,6 +13,7 @@ Group:		System Environment/Libraries
 License:        ASL 2.0
 URL:		https://github.com/SpectraLogic/ds3_c_sdk
 Source:		%{_commit}.tar.gz
+Patch0:         active_jobs.patch
 BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildRequires:  gcc
@@ -38,6 +39,7 @@ Spectra S3 C SDK Development Libraries and Headers
 
 %prep
 %setup -q -n ds3_c_sdk-%{_commit}
+%patch -P 0 -p1
 
 %build
 


### PR DESCRIPTION
The upstream ds3 sdk has bugs in the xml parsing and error handling.
Filed https://github.com/SpectraLogic/ds3_c_sdk/issues/234 but we can
patch on our own until that gets fixed.

[sc-39961]